### PR TITLE
Small fix

### DIFF
--- a/wrangle.R
+++ b/wrangle.R
@@ -4,7 +4,7 @@
 
 adjust_lags <- function(tbl_in, max_lag){
   
-  other_lags <- tbl_in$lag[tbl_in$lag >= max_lag]
+  other_lags <- as.character(tbl_in$lag[tbl_in$lag >= max_lag])
   
   tbl_in |> 
     mutate(


### PR DESCRIPTION
Brian - I had to make this small fix to deal with an error.
This is the error: 
```
Caused by error in `fct_other()`:
! `drop` must be a character vector, not an integer vector.

```

and I presume that's because `other_lags` was (or was coerced to) a numeric vector.